### PR TITLE
Improve tab titles for 1.8 - 1.12

### DIFF
--- a/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_10/EffTabTitlesV1_10.java
+++ b/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_10/EffTabTitlesV1_10.java
@@ -54,20 +54,17 @@ public class EffTabTitlesV1_10 extends Effect {
                 ChatSerializer.a("{\"text\": \"" + coreHeader.getSingle(evt).replace("\"", "") + "\"}");
         IChatBaseComponent footer =
                 ChatSerializer.a("{\"text\": \"" + coreFooter.getSingle(evt).replace("\"", "") + "\"}");
-        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
-        try {
-            Field headerField = packet.getClass().getDeclaredField("a");
-            headerField.setAccessible(true);
-            headerField.set(packet, header);
-            headerField.setAccessible(!headerField.isAccessible());
+        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter(header);
 
+        try {
             Field footerField = packet.getClass().getDeclaredField("b");
             footerField.setAccessible(true);
             footerField.set(packet, footer);
-            footerField.setAccessible(!footerField.isAccessible());
+            footerField.setAccessible(false);
         } catch (Exception exception) {
             exception.printStackTrace();
         }
+
         ((CraftPlayer) player.getSingle(evt)).getHandle().playerConnection.sendPacket(packet);
     }
 }

--- a/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_11/EffTabTitlesV1_11.java
+++ b/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_11/EffTabTitlesV1_11.java
@@ -54,20 +54,17 @@ public class EffTabTitlesV1_11 extends Effect {
                 ChatSerializer.a("{\"text\": \"" + coreHeader.getSingle(evt).replace("\"", "") + "\"}");
         IChatBaseComponent footer =
                 ChatSerializer.a("{\"text\": \"" + coreFooter.getSingle(evt).replace("\"", "") + "\"}");
-        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
-        try {
-            Field headerField = packet.getClass().getDeclaredField("a");
-            headerField.setAccessible(true);
-            headerField.set(packet, header);
-            headerField.setAccessible(!headerField.isAccessible());
+        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter(header);
 
+        try {
             Field footerField = packet.getClass().getDeclaredField("b");
             footerField.setAccessible(true);
             footerField.set(packet, footer);
-            footerField.setAccessible(!footerField.isAccessible());
+            footerField.setAccessible(false);
         } catch (Exception exception) {
             exception.printStackTrace();
         }
+
         ((CraftPlayer) player.getSingle(evt)).getHandle().playerConnection.sendPacket(packet);
     }
 }

--- a/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_12/EffTabTitlesV1_12.java
+++ b/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_12/EffTabTitlesV1_12.java
@@ -52,20 +52,17 @@ public class EffTabTitlesV1_12 extends Effect {
                 ChatSerializer.a("{\"text\": \"" + coreHeader.getSingle(evt).replace("\"", "") + "\"}");
         IChatBaseComponent footer =
                 ChatSerializer.a("{\"text\": \"" + coreFooter.getSingle(evt).replace("\"", "") + "\"}");
-        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
-        try {
-            Field headerField = packet.getClass().getDeclaredField("a");
-            headerField.setAccessible(true);
-            headerField.set(packet, header);
-            headerField.setAccessible(!headerField.isAccessible());
+        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter(header);
 
+        try {
             Field footerField = packet.getClass().getDeclaredField("b");
             footerField.setAccessible(true);
             footerField.set(packet, footer);
-            footerField.setAccessible(!footerField.isAccessible());
+            footerField.setAccessible(false);
         } catch (Exception exception) {
             exception.printStackTrace();
         }
+
         ((CraftPlayer) player.getSingle(evt)).getHandle().playerConnection.sendPacket(packet);
     }
 }

--- a/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_8/EffTabTitlesV1_8.java
+++ b/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_8/EffTabTitlesV1_8.java
@@ -54,20 +54,17 @@ public class EffTabTitlesV1_8 extends Effect {
                 ChatSerializer.a("{\"text\": \"" + coreHeader.getSingle(evt).replace("\"", "") + "\"}");
         IChatBaseComponent footer =
                 ChatSerializer.a("{\"text\": \"" + coreFooter.getSingle(evt).replace("\"", "") + "\"}");
-        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
-        try {
-            Field headerField = packet.getClass().getDeclaredField("a");
-            headerField.setAccessible(true);
-            headerField.set(packet, header);
-            headerField.setAccessible(!headerField.isAccessible());
+        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter(header);
 
+        try {
             Field footerField = packet.getClass().getDeclaredField("b");
             footerField.setAccessible(true);
             footerField.set(packet, footer);
-            footerField.setAccessible(!footerField.isAccessible());
+            footerField.setAccessible(false);
         } catch (Exception exception) {
             exception.printStackTrace();
         }
+
         ((CraftPlayer) player.getSingle(evt)).getHandle().playerConnection.sendPacket(packet);
     }
 }

--- a/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_8_3/EffTabTitlesV1_8_3.java
+++ b/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_8_3/EffTabTitlesV1_8_3.java
@@ -54,20 +54,17 @@ public class EffTabTitlesV1_8_3 extends Effect {
                 ChatSerializer.a("{\"text\": \"" + coreHeader.getSingle(evt).replace("\"", "") + "\"}");
         IChatBaseComponent footer =
                 ChatSerializer.a("{\"text\": \"" + coreFooter.getSingle(evt).replace("\"", "") + "\"}");
-        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
-        try {
-            Field headerField = packet.getClass().getDeclaredField("a");
-            headerField.setAccessible(true);
-            headerField.set(packet, header);
-            headerField.setAccessible(!headerField.isAccessible());
+        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter(header);
 
+        try {
             Field footerField = packet.getClass().getDeclaredField("b");
             footerField.setAccessible(true);
             footerField.set(packet, footer);
-            footerField.setAccessible(!footerField.isAccessible());
+            footerField.setAccessible(false);
         } catch (Exception exception) {
             exception.printStackTrace();
         }
+
         ((CraftPlayer) player.getSingle(evt)).getHandle().playerConnection.sendPacket(packet);
     }
 }

--- a/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_8_4/EffTabTitlesV1_8_4.java
+++ b/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_8_4/EffTabTitlesV1_8_4.java
@@ -54,20 +54,17 @@ public class EffTabTitlesV1_8_4 extends Effect {
                 ChatSerializer.a("{\"text\": \"" + coreHeader.getSingle(evt).replace("\"", "") + "\"}");
         IChatBaseComponent footer =
                 ChatSerializer.a("{\"text\": \"" + coreFooter.getSingle(evt).replace("\"", "") + "\"}");
-        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
-        try {
-            Field headerField = packet.getClass().getDeclaredField("a");
-            headerField.setAccessible(true);
-            headerField.set(packet, header);
-            headerField.setAccessible(!headerField.isAccessible());
+        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter(header);
 
+        try {
             Field footerField = packet.getClass().getDeclaredField("b");
             footerField.setAccessible(true);
             footerField.set(packet, footer);
-            footerField.setAccessible(!footerField.isAccessible());
+            footerField.setAccessible(false);
         } catch (Exception exception) {
             exception.printStackTrace();
         }
+
         ((CraftPlayer) player.getSingle(evt)).getHandle().playerConnection.sendPacket(packet);
     }
 }

--- a/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_9/EffTabTitlesV1_9.java
+++ b/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_9/EffTabTitlesV1_9.java
@@ -54,20 +54,17 @@ public class EffTabTitlesV1_9 extends Effect {
                 ChatSerializer.a("{\"text\": \"" + coreHeader.getSingle(evt).replace("\"", "") + "\"}");
         IChatBaseComponent footer =
                 ChatSerializer.a("{\"text\": \"" + coreFooter.getSingle(evt).replace("\"", "") + "\"}");
-        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
-        try {
-            Field headerField = packet.getClass().getDeclaredField("a");
-            headerField.setAccessible(true);
-            headerField.set(packet, header);
-            headerField.setAccessible(!headerField.isAccessible());
+        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter(header);
 
+        try {
             Field footerField = packet.getClass().getDeclaredField("b");
             footerField.setAccessible(true);
             footerField.set(packet, footer);
-            footerField.setAccessible(!footerField.isAccessible());
+            footerField.setAccessible(false);
         } catch (Exception exception) {
             exception.printStackTrace();
         }
+
         ((CraftPlayer) player.getSingle(evt)).getHandle().playerConnection.sendPacket(packet);
     }
 }

--- a/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_9_4/EffTabTitlesV1_9_4.java
+++ b/src/main/java/net/rayfall/eyesniper2/skrayfall/v1_9_4/EffTabTitlesV1_9_4.java
@@ -54,20 +54,17 @@ public class EffTabTitlesV1_9_4 extends Effect {
                 ChatSerializer.a("{\"text\": \"" + coreHeader.getSingle(evt).replace("\"", "") + "\"}");
         IChatBaseComponent footer =
                 ChatSerializer.a("{\"text\": \"" + coreFooter.getSingle(evt).replace("\"", "") + "\"}");
-        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter();
-        try {
-            Field headerField = packet.getClass().getDeclaredField("a");
-            headerField.setAccessible(true);
-            headerField.set(packet, header);
-            headerField.setAccessible(!headerField.isAccessible());
+        PacketPlayOutPlayerListHeaderFooter packet = new PacketPlayOutPlayerListHeaderFooter(header);
 
+        try {
             Field footerField = packet.getClass().getDeclaredField("b");
             footerField.setAccessible(true);
             footerField.set(packet, footer);
-            footerField.setAccessible(!footerField.isAccessible());
+            footerField.setAccessible(false);
         } catch (Exception exception) {
             exception.printStackTrace();
         }
+
         ((CraftPlayer) player.getSingle(evt)).getHandle().playerConnection.sendPacket(packet);
     }
 }


### PR DESCRIPTION
At least in legacy versions, the field `a` (tab header) of `PacketPlayOutPlayerListHeaderFooter` can already be defined via constructor.